### PR TITLE
Document that simulator config files should be committed

### DIFF
--- a/FRC_CODING_INSTRUCTIONS.md
+++ b/FRC_CODING_INSTRUCTIONS.md
@@ -547,6 +547,18 @@ The WPILib command scheduler runs everything in a single thread. This means:
 
 ---
 
+## Repository Contents
+
+### Simulator Configuration Files
+Simulator configuration files (such as `simgui-ds.json`, `simgui.json`, and similar) **should be committed** to the repository. These files:
+- Store joystick mappings and driver station configurations for simulation
+- Ensure consistent simulation experience across all team members
+- Are necessary for the robot simulation to function properly with the expected controls
+
+Do not add these files to `.gitignore`.
+
+---
+
 ## Additional Resources
 
 - Full reference: https://therekrab.github.io/frc-programming-reference/


### PR DESCRIPTION
Add Repository Contents section to clarify that simgui-ds.json and similar simulator configuration files are necessary and should be included in commits for consistent simulation experience.